### PR TITLE
Remove ApiKey from parameters dictionary

### DIFF
--- a/ecommerce_extensions/payment/processors/payu.py
+++ b/ecommerce_extensions/payment/processors/payu.py
@@ -71,7 +71,6 @@ class Payu(BasePaymentProcessor):
             'payment_page_url': self.payment_page_url,
             'merchantId': self.merchant_id,
             'accountId': self.account_id,
-            'ApiKey': self.api_key,
             'referenceCode': basket.order_number,
             'tax': self.tax,
             'taxReturnBase': self.tax_return_base,


### PR DESCRIPTION
This PR removes apikey from parameters dictionary to avoid send it in the POST request.