### PR TITLE
Add auth backend

### DIFF
--- a/ecommerce_extensions/auth_backends/backends.py
+++ b/ecommerce_extensions/auth_backends/backends.py
@@ -1,0 +1,13 @@
+"""Ecommerce extensions custom backends"""
+from auth_backends.backends import PROFILE_CLAIMS_TO_DETAILS_KEY_MAP, EdXOAuth2
+from django.conf import settings
+
+
+class EcommerceExtensionsAuth2(EdXOAuth2):
+    """This class is a wrapper of auth_backends.backends.EdXOAuth2, this allows
+    to override the value of CLAIMS_TO_DETAILS_KEY_MAP by using django-conf.settings
+    """
+
+    @property
+    def CLAIMS_TO_DETAILS_KEY_MAP(self):
+        return getattr(settings, "PROFILE_CLAIMS_TO_DETAILS_KEY_MAP", PROFILE_CLAIMS_TO_DETAILS_KEY_MAP)

--- a/ecommerce_extensions/auth_backends/backends.py
+++ b/ecommerce_extensions/auth_backends/backends.py
@@ -3,11 +3,12 @@ from auth_backends.backends import PROFILE_CLAIMS_TO_DETAILS_KEY_MAP, EdXOAuth2
 from django.conf import settings
 
 
-class EcommerceExtensionsAuth2(EdXOAuth2):
+class EcommerceExtensionsAuth2(EdXOAuth2):  # pylint: disable=abstract-method
     """This class is a wrapper of auth_backends.backends.EdXOAuth2, this allows
     to override the value of CLAIMS_TO_DETAILS_KEY_MAP by using django-conf.settings
     """
 
     @property
     def CLAIMS_TO_DETAILS_KEY_MAP(self):
+        """Return the value of PROFILE_CLAIMS_TO_DETAILS_KEY_MAP from django settings."""
         return getattr(settings, "PROFILE_CLAIMS_TO_DETAILS_KEY_MAP", PROFILE_CLAIMS_TO_DETAILS_KEY_MAP)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,6 +5,7 @@ Django
 django-compressor
 django-oscar
 djangorestframework
+edx-auth-backends
 jsonfield2
 qrcode
 sorl-thumbnail

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,30 +4,134 @@
 #
 #    make upgrade
 #
-babel==2.9.0              # via django-oscar, django-phonenumber-field
-django-appconf==1.0.4     # via django-compressor
-django-compressor==2.4    # via -r requirements/base.in
-django-extra-views==0.11.0  # via django-oscar
-django-haystack==2.8.1    # via django-oscar
-django-oscar==2.0.4       # via -c requirements/constraints.txt, -r requirements/base.in
-django-phonenumber-field==2.0.1  # via django-oscar
-django-tables2==1.21.2    # via django-oscar
-django-treebeard==4.3.1   # via django-oscar
-django-widget-tweaks==1.4.8  # via django-oscar
-django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, django-appconf, django-extra-views, django-haystack, django-oscar, django-phonenumber-field, django-tables2, django-treebeard, djangorestframework, jsonfield2
-djangorestframework==3.11.0  # via -c requirements/constraints.txt, -r requirements/base.in
-factory-boy==2.12.0       # via django-oscar
-faker==5.0.0              # via factory-boy
-jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in
-phonenumbers==8.12.16     # via django-oscar, django-phonenumber-field
-pillow==7.2.0             # via django-oscar
-purl==1.5                 # via django-oscar
-python-dateutil==2.8.1    # via faker
-pytz==2020.5              # via babel, django
-qrcode==6.1               # via -r requirements/base.in
-rcssmin==1.0.6            # via django-compressor
-rjsmin==1.1.0             # via django-compressor
-six==1.15.0               # via django-compressor, django-extra-views, purl, python-dateutil, qrcode
-sorl-thumbnail==12.7.0    # via -r requirements/base.in
-sqlparse==0.4.1           # via django
-text-unidecode==1.3       # via faker
+babel==2.9.0
+    # via
+    #   django-oscar
+    #   django-phonenumber-field
+certifi==2020.12.5
+    # via requests
+cffi==1.14.4
+    # via cryptography
+chardet==4.0.0
+    # via requests
+cryptography==3.2.1
+    # via social-auth-core
+defusedxml==0.6.0
+    # via
+    #   python3-openid
+    #   social-auth-core
+django-appconf==1.0.4
+    # via django-compressor
+django-compressor==2.4
+    # via -r requirements/base.in
+django-extra-views==0.11.0
+    # via django-oscar
+django-haystack==2.8.1
+    # via django-oscar
+django-oscar==2.0.4
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+django-phonenumber-field==2.0.1
+    # via django-oscar
+django-tables2==1.21.2
+    # via django-oscar
+django-treebeard==4.3.1
+    # via django-oscar
+django-widget-tweaks==1.4.8
+    # via django-oscar
+django==2.2.17
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+    #   django-appconf
+    #   django-extra-views
+    #   django-haystack
+    #   django-oscar
+    #   django-phonenumber-field
+    #   django-tables2
+    #   django-treebeard
+    #   djangorestframework
+    #   edx-auth-backends
+    #   jsonfield2
+djangorestframework==3.11.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+edx-auth-backends==3.0.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+factory-boy==2.12.0
+    # via django-oscar
+faker==5.0.0
+    # via factory-boy
+idna==2.10
+    # via requests
+jsonfield2==3.0.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+oauthlib==3.1.0
+    # via
+    #   requests-oauthlib
+    #   social-auth-core
+phonenumbers==8.12.16
+    # via
+    #   django-oscar
+    #   django-phonenumber-field
+pillow==7.2.0
+    # via django-oscar
+purl==1.5
+    # via django-oscar
+pycparser==2.20
+    # via cffi
+pyjwt==1.7.1
+    # via
+    #   edx-auth-backends
+    #   social-auth-core
+python-dateutil==2.8.1
+    # via faker
+python3-openid==3.2.0
+    # via social-auth-core
+pytz==2020.5
+    # via
+    #   babel
+    #   django
+qrcode==6.1
+    # via -r requirements/base.in
+rcssmin==1.0.6
+    # via django-compressor
+requests-oauthlib==1.3.0
+    # via social-auth-core
+requests==2.25.1
+    # via
+    #   requests-oauthlib
+    #   social-auth-core
+rjsmin==1.1.0
+    # via django-compressor
+six==1.15.0
+    # via
+    #   cryptography
+    #   django-compressor
+    #   django-extra-views
+    #   edx-auth-backends
+    #   purl
+    #   python-dateutil
+    #   qrcode
+    #   social-auth-app-django
+    #   social-auth-core
+social-auth-app-django==3.4.0
+    # via edx-auth-backends
+social-auth-core==3.4.0
+    # via
+    #   edx-auth-backends
+    #   social-auth-app-django
+sorl-thumbnail==12.7.0
+    # via -r requirements/base.in
+sqlparse==0.4.1
+    # via django
+text-unidecode==1.3
+    # via faker
+urllib3==1.26.2
+    # via requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -23,4 +23,5 @@ zipp<2.0.0
 #keep the same juniper release versions.
 django-oscar==2.0.4
 djangorestframework==3.11.0
+edx-auth-backends==3.0.2
 jsonfield2==3.0.3

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,8 +4,10 @@
 #
 #    make upgrade
 #
-click==7.1.2              # via pip-tools
-pip-tools==5.5.0          # via -r requirements/pip-tools.in
+click==7.1.2
+    # via pip-tools
+pip-tools==5.5.0
+    # via -r requirements/pip-tools.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,49 +4,233 @@
 #
 #    make upgrade
 #
-astroid==2.4.2            # via pylint
-babel==2.9.0              # via -r requirements/base.txt, django-oscar, django-phonenumber-field
-certifi==2020.12.5        # via requests
-chardet==4.0.0            # via requests
-codecov==2.1.11           # via -r requirements/test.in
-coverage==5.3.1           # via -r requirements/test.in, codecov
-ddt==1.4.1                # via -r requirements/test.in
-django-appconf==1.0.4     # via -r requirements/base.txt, django-compressor
-django-compressor==2.4    # via -r requirements/base.txt
-django-extra-views==0.11.0  # via -r requirements/base.txt, django-oscar
-django-haystack==2.8.1    # via -r requirements/base.txt, django-oscar
-django-oscar==2.0.4       # via -c requirements/constraints.txt, -r requirements/base.txt
-django-phonenumber-field==2.0.1  # via -r requirements/base.txt, django-oscar
-django-tables2==1.21.2    # via -r requirements/base.txt, django-oscar
-django-treebeard==4.3.1   # via -r requirements/base.txt, django-oscar
-django-widget-tweaks==1.4.8  # via -r requirements/base.txt, django-oscar
-django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.txt, django-appconf, django-extra-views, django-haystack, django-oscar, django-phonenumber-field, django-tables2, django-treebeard, djangorestframework, jsonfield2
-djangorestframework==3.11.0  # via -c requirements/constraints.txt, -r requirements/base.txt
-factory-boy==2.12.0       # via -r requirements/base.txt, django-oscar
-faker==5.0.0              # via -r requirements/base.txt, factory-boy
-idna==2.10                # via requests
-isort==4.3.21             # via -c requirements/constraints.txt, pylint
-jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.txt, -r requirements/test.in
-lazy-object-proxy==1.4.3  # via astroid
-mccabe==0.6.1             # via pylint
-mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
-phonenumbers==8.12.16     # via -r requirements/base.txt, django-oscar, django-phonenumber-field
-pillow==7.2.0             # via -r requirements/base.txt, django-oscar
-purl==1.5                 # via -r requirements/base.txt, django-oscar
-pycodestyle==2.6.0        # via -r requirements/test.in
-pylint==2.6.0             # via -r requirements/test.in
-python-dateutil==2.8.1    # via -r requirements/base.txt, faker
-pytz==2020.5              # via -r requirements/base.txt, babel, django
-qrcode==6.1               # via -r requirements/base.txt
-rcssmin==1.0.6            # via -r requirements/base.txt, django-compressor
-requests==2.25.1          # via codecov
-rjsmin==1.1.0             # via -r requirements/base.txt, django-compressor
-six==1.15.0               # via -r requirements/base.txt, astroid, django-compressor, django-extra-views, mock, purl, python-dateutil, qrcode
-sorl-thumbnail==12.7.0    # via -r requirements/base.txt
-sqlparse==0.4.1           # via -r requirements/base.txt, django
-testfixtures==6.17.1      # via -r requirements/test.in
-text-unidecode==1.3       # via -r requirements/base.txt, faker
-toml==0.10.2              # via pylint
-typed-ast==1.4.2          # via astroid
-urllib3==1.26.2           # via requests
-wrapt==1.12.1             # via astroid
+astroid==2.4.2
+    # via pylint
+babel==2.9.0
+    # via
+    #   -r requirements/base.txt
+    #   django-oscar
+    #   django-phonenumber-field
+certifi==2020.12.5
+    # via
+    #   -r requirements/base.txt
+    #   requests
+cffi==1.14.4
+    # via
+    #   -r requirements/base.txt
+    #   cryptography
+chardet==4.0.0
+    # via
+    #   -r requirements/base.txt
+    #   requests
+codecov==2.1.11
+    # via -r requirements/test.in
+coverage==5.3.1
+    # via
+    #   -r requirements/test.in
+    #   codecov
+cryptography==3.2.1
+    # via
+    #   -r requirements/base.txt
+    #   social-auth-core
+ddt==1.4.1
+    # via -r requirements/test.in
+defusedxml==0.6.0
+    # via
+    #   -r requirements/base.txt
+    #   python3-openid
+    #   social-auth-core
+django-appconf==1.0.4
+    # via
+    #   -r requirements/base.txt
+    #   django-compressor
+django-compressor==2.4
+    # via -r requirements/base.txt
+django-extra-views==0.11.0
+    # via
+    #   -r requirements/base.txt
+    #   django-oscar
+django-haystack==2.8.1
+    # via
+    #   -r requirements/base.txt
+    #   django-oscar
+django-oscar==2.0.4
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+django-phonenumber-field==2.0.1
+    # via
+    #   -r requirements/base.txt
+    #   django-oscar
+django-tables2==1.21.2
+    # via
+    #   -r requirements/base.txt
+    #   django-oscar
+django-treebeard==4.3.1
+    # via
+    #   -r requirements/base.txt
+    #   django-oscar
+django-widget-tweaks==1.4.8
+    # via
+    #   -r requirements/base.txt
+    #   django-oscar
+django==2.2.17
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   django-appconf
+    #   django-extra-views
+    #   django-haystack
+    #   django-oscar
+    #   django-phonenumber-field
+    #   django-tables2
+    #   django-treebeard
+    #   djangorestframework
+    #   edx-auth-backends
+    #   jsonfield2
+djangorestframework==3.11.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+edx-auth-backends==3.0.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+factory-boy==2.12.0
+    # via
+    #   -r requirements/base.txt
+    #   django-oscar
+faker==5.0.0
+    # via
+    #   -r requirements/base.txt
+    #   factory-boy
+idna==2.10
+    # via
+    #   -r requirements/base.txt
+    #   requests
+isort==4.3.21
+    # via
+    #   -c requirements/constraints.txt
+    #   pylint
+jsonfield2==3.0.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.in
+lazy-object-proxy==1.4.3
+    # via astroid
+mccabe==0.6.1
+    # via pylint
+mock==3.0.5
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.in
+oauthlib==3.1.0
+    # via
+    #   -r requirements/base.txt
+    #   requests-oauthlib
+    #   social-auth-core
+phonenumbers==8.12.16
+    # via
+    #   -r requirements/base.txt
+    #   django-oscar
+    #   django-phonenumber-field
+pillow==7.2.0
+    # via
+    #   -r requirements/base.txt
+    #   django-oscar
+purl==1.5
+    # via
+    #   -r requirements/base.txt
+    #   django-oscar
+pycodestyle==2.6.0
+    # via -r requirements/test.in
+pycparser==2.20
+    # via
+    #   -r requirements/base.txt
+    #   cffi
+pyjwt==1.7.1
+    # via
+    #   -r requirements/base.txt
+    #   edx-auth-backends
+    #   social-auth-core
+pylint==2.6.0
+    # via -r requirements/test.in
+python-dateutil==2.8.1
+    # via
+    #   -r requirements/base.txt
+    #   faker
+python3-openid==3.2.0
+    # via
+    #   -r requirements/base.txt
+    #   social-auth-core
+pytz==2020.5
+    # via
+    #   -r requirements/base.txt
+    #   babel
+    #   django
+qrcode==6.1
+    # via -r requirements/base.txt
+rcssmin==1.0.6
+    # via
+    #   -r requirements/base.txt
+    #   django-compressor
+requests-oauthlib==1.3.0
+    # via
+    #   -r requirements/base.txt
+    #   social-auth-core
+requests==2.25.1
+    # via
+    #   -r requirements/base.txt
+    #   codecov
+    #   requests-oauthlib
+    #   social-auth-core
+rjsmin==1.1.0
+    # via
+    #   -r requirements/base.txt
+    #   django-compressor
+six==1.15.0
+    # via
+    #   -r requirements/base.txt
+    #   astroid
+    #   cryptography
+    #   django-compressor
+    #   django-extra-views
+    #   edx-auth-backends
+    #   mock
+    #   purl
+    #   python-dateutil
+    #   qrcode
+    #   social-auth-app-django
+    #   social-auth-core
+social-auth-app-django==3.4.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-auth-backends
+social-auth-core==3.4.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-auth-backends
+    #   social-auth-app-django
+sorl-thumbnail==12.7.0
+    # via -r requirements/base.txt
+sqlparse==0.4.1
+    # via
+    #   -r requirements/base.txt
+    #   django
+testfixtures==6.17.1
+    # via -r requirements/test.in
+text-unidecode==1.3
+    # via
+    #   -r requirements/base.txt
+    #   faker
+toml==0.10.2
+    # via pylint
+typed-ast==1.4.2
+    # via astroid
+urllib3==1.26.2
+    # via
+    #   -r requirements/base.txt
+    #   requests
+wrapt==1.12.1
+    # via astroid

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,17 +4,41 @@
 #
 #    make upgrade
 #
-appdirs==1.4.4            # via virtualenv
-distlib==0.3.1            # via virtualenv
-filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==2.1.1  # via pluggy, tox, virtualenv
-importlib-resources==3.2.1  # via virtualenv
-packaging==20.8           # via tox
-pluggy==0.13.1            # via tox
-py==1.10.0                # via tox
-pyparsing==2.4.7          # via packaging
-six==1.15.0               # via tox, virtualenv
-toml==0.10.2              # via tox
-tox==3.21.1               # via -r requirements/tox.in
-virtualenv==20.3.1        # via tox
-zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources
+appdirs==1.4.4
+    # via virtualenv
+distlib==0.3.1
+    # via virtualenv
+filelock==3.0.12
+    # via
+    #   tox
+    #   virtualenv
+importlib-metadata==2.1.1
+    # via
+    #   pluggy
+    #   tox
+    #   virtualenv
+importlib-resources==3.2.1
+    # via virtualenv
+packaging==20.8
+    # via tox
+pluggy==0.13.1
+    # via tox
+py==1.10.0
+    # via tox
+pyparsing==2.4.7
+    # via packaging
+six==1.15.0
+    # via
+    #   tox
+    #   virtualenv
+toml==0.10.2
+    # via tox
+tox==3.21.1
+    # via -r requirements/tox.in
+virtualenv==20.3.1
+    # via tox
+zipp==1.2.0
+    # via
+    #   -c requirements/constraints.txt
+    #   importlib-metadata
+    #   importlib-resources


### PR DESCRIPTION
## Description 
This add a backend that allows to read the detail keys from django settings.
The original backend uses a constant https://github.com/edx/auth-backends/blob/master/auth_backends/backends.py#L35

To use this the backend has to be add to the AUTHENTICATION_BACKENDS setting.

