### PR TITLE
feat: add extra_script and add script to context_processors

### DIFF
--- a/ecommerce_extensions/tenant/context_processors.py
+++ b/ecommerce_extensions/tenant/context_processors.py
@@ -4,6 +4,7 @@ This file contains django context_processors needed by edunext.
 """
 import logging
 
+from ecommerce_extensions.tenant.extra_scripts import process_scripts
 from ecommerce_extensions.tenant.models import TenantOptions
 
 LOG = logging.getLogger(__name__)
@@ -25,8 +26,11 @@ def theme_options(request):
     except AttributeError:
         site_theme_name = None
 
+    theme_options_values = options.get("THEME_OPTIONS", {})
+
     return {
         "theme_dir_name": site_theme_name,
         "site_configuration": request.site.siteconfiguration,
         "options": options,
+        "scripts": process_scripts(request.path_info, theme_options_values)
     }

--- a/ecommerce_extensions/tenant/extra_options.py
+++ b/ecommerce_extensions/tenant/extra_options.py
@@ -1,0 +1,52 @@
+"""
+This function gets called during every request by the
+extra_html and extra_scripts to validate all the custom html and scripts for a specific path.
+"""
+import logging
+
+logger = logging.getLogger(__name__)
+
+ERROR_MESSAGE = "could not get loaded. '%s' attribute is missing or is an invalid option."
+
+
+def set_default_option(values, key, allowed_values, default_value):
+    """
+    Set the default option if the values[key] does not match the allowed values.
+
+    Parameters:
+        values (dict): a dict with values to set option default
+        key (string): a key when to set option default
+        allowed_values (array): an array of allowed values
+        default_value (string): a value default to set in values with key
+
+    Returns:
+        dict: a dict with values seted according option default
+    """
+    if values.get(key) not in allowed_values:
+        values[key] = default_value
+
+    return values
+
+
+def check_attributes_required(values, attributes, error_message_prefix):
+    """
+    Validate the existence of at least one attribute in attributes.
+
+    Parameters:
+        values (dict): a dict with values to validate according to attributes
+        attributes (array): a array with attributes to validate
+        error_message_prefix (string): a string prefix to error message
+
+    Returns:
+        bool: a boolean indicating whether at least one attribute is in attributes.
+    """
+    for attribute in attributes:
+        if attribute in values:
+            return True
+
+    logger.error(
+        "{prefix} {error_message}".format(prefix=error_message_prefix, error_message=ERROR_MESSAGE),
+        attributes
+    )
+
+    return False

--- a/ecommerce_extensions/tenant/extra_scripts.py
+++ b/ecommerce_extensions/tenant/extra_scripts.py
@@ -1,0 +1,48 @@
+"""
+This function gets called during every request by the
+context processor to return all the custom scripts for a specific path.
+"""
+import re
+
+from ecommerce_extensions.tenant.extra_options import check_attributes_required, set_default_option
+
+
+def process_scripts(path, options):
+    """
+    Process and loads all the extra scripts for the template
+    rendered during the request.
+
+    Parameters:
+        path (string): a regex for a url of a given site
+        options (dict): a list of javascript scripts separated by a path
+
+    Returns:
+        dict: a list of separate javascript scripts validated according to regex in path
+    """
+    scripts = options.get('scripts', {})
+
+    if isinstance(scripts, dict):
+        for regex, values in scripts.items():
+            regex_path_match = re.compile(regex)
+            if regex_path_match.match(path):
+                scripts = []
+                for script in values:
+                    set_defaul_to_script = set_default_option(
+                        script,
+                        'media_type',
+                        ['module', 'text/javascript'],
+                        'text/javascript'
+                    )
+
+                    # Validate 'src' or 'content' key in script
+                    is_validate_script = check_attributes_required(
+                        set_defaul_to_script,
+                        ['src', 'content'],
+                        "Script"
+                    )
+                    if is_validate_script:
+                        scripts.append(set_defaul_to_script)
+                if scripts:
+                    return scripts
+
+    return None

--- a/ecommerce_extensions/tenant/tests/test_extra_scripts.py
+++ b/ecommerce_extensions/tenant/tests/test_extra_scripts.py
@@ -1,0 +1,106 @@
+"""
+Tests for the extra scripts.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from django.test import TestCase
+from path import Path
+from testfixtures import LogCapture
+
+from ecommerce_extensions.tenant.extra_options import ERROR_MESSAGE, check_attributes_required
+from ecommerce_extensions.tenant.extra_scripts import process_scripts
+
+
+class TestsProcessExtraScripts(TestCase):
+    """ Tests for extra scripts"""
+
+    def test_returned_process_scripts(self):
+        """
+        Test process_scripts function returns a dictionary with all the valid scripts
+        in the correct order.
+        """
+        path = Path("/test")
+        tenantoptions = {
+            "scripts": {
+                ".*/test": [
+                    {
+                        "src": "https://www.test-external-script.com/js/myScript1.js",
+                        "media_type": "module"
+                    },
+                    {
+                        "content": "alert('This alert box was called with the onload event');"
+                    }
+                ]
+            }
+        }
+        test_scripts = [
+            {
+                "src": "https://www.test-external-script.com/js/myScript1.js",
+                "media_type": "module"
+            },
+            {
+                "content": "alert('This alert box was called with the onload event');",
+                "media_type": "text/javascript"
+            },
+        ]
+
+        scripts = process_scripts(path, tenantoptions)
+
+        self.assertEqual(test_scripts, scripts)
+
+    def test_returned_(self):
+        """
+        Test process_scripts function returns only the scripts that have a valid configuration.
+        """
+        path = Path("/test")
+        tenantoptions = {
+            "scripts": {
+                ".*/test": [
+                    {
+                        "conten": "alert('This alert box was called with the onload event');"
+                    }
+                ]
+            }
+        }
+
+        scripts = process_scripts(path, tenantoptions)
+
+        self.assertIsNone(scripts)
+
+    def test_returned_path_scripts(self):
+        """
+        Test process_scripts function returns only the scripts that match the current request path.
+        """
+        path = Path("/test")
+        tenantoptions = {
+            "scripts": {
+                ".*/dashboard": [
+                    {
+                        "src": "https://www.test-external-script.com/js/myScript1.js",
+                        "media_type": "text/javascript"
+                    }
+                ]
+            }
+        }
+
+        scripts = process_scripts(path, tenantoptions)
+
+        self.assertIsNone(scripts)
+
+    def test_check_attributes_required_fails_silently(self):
+        """
+        Test check_attributes_required function logs error when a script has a missing/incorrect attribute.
+        """
+        values = {}
+        attributes = ['src', 'content']
+        log_message = "{prefix} {error_message}".format(prefix="Script", error_message=ERROR_MESSAGE) % attributes
+
+        with LogCapture() as log:
+            check_attributes_required(
+                values,
+                attributes,
+                "Script"
+            )
+            log.check(("ecommerce_extensions.tenant.extra_options",
+                       "ERROR",
+                       log_message))

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -6,6 +6,7 @@ coverage
 ddt
 jsonfield2
 mock
+path.py
 pycodestyle
 pylint
 testfixtures

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -130,6 +130,8 @@ oauthlib==3.1.0
     #   -r requirements/base.txt
     #   requests-oauthlib
     #   social-auth-core
+path.py==8.2.1            
+    # via -r requirements/test.in
 phonenumbers==8.12.16
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
This PR allows adding custom scripts for each template of ecommerce.

For example: to add a specific script to the basket template, add the path and the configurations of the script
to the tenant options.
`"THEME_OPTIONS": { 
       "scripts": { 
           "/basket": [ 
               { "src": "https://www.test.com/js/myScript1.js" }, 
               { "media_type":"module", "content": "alert('This alert box was called with the onload event');" }
           ]
       }
}`

The attributes that can be specified are:

media_type : 'module' or 'text/javascript'
The media_type attribute has 'text/javascript' as its default value.
In the script you need to add the attribute 'src' or 'content'.

This PR arises to adapt the logic exposed in PR https://github.com/eduNEXT/eox-theming/pull/29 to ecommerce-extension.