### PR TITLE
Jipm/add extra html

### DIFF
--- a/ecommerce_extensions/tenant/context_processors.py
+++ b/ecommerce_extensions/tenant/context_processors.py
@@ -4,6 +4,7 @@ This file contains django context_processors needed by edunext.
 """
 import logging
 
+from ecommerce_extensions.tenant.extra_html import process_html
 from ecommerce_extensions.tenant.extra_scripts import process_scripts
 from ecommerce_extensions.tenant.models import TenantOptions
 
@@ -32,5 +33,6 @@ def theme_options(request):
         "theme_dir_name": site_theme_name,
         "site_configuration": request.site.siteconfiguration,
         "options": options,
-        "scripts": process_scripts(request.path_info, theme_options_values)
+        "scripts": process_scripts(request.path_info, theme_options_values),
+        "html": process_html(request.path_info, theme_options_values)
     }

--- a/ecommerce_extensions/tenant/extra_html.py
+++ b/ecommerce_extensions/tenant/extra_html.py
@@ -1,0 +1,49 @@
+"""
+This function gets called during every request by the
+context processor to return all the custom html for a specific path.
+"""
+import re
+
+from ecommerce_extensions.tenant.extra_options import check_attributes_required, set_default_option
+
+
+def process_html(path, options):
+    """
+    Process and loads all the extra html for the template
+    rendered during the request.
+
+    Parameters:
+        path (string): a regex for a url of a given site
+        options (dict): a list of separate html separated by a path
+
+    Returns:
+        dict: a list of separate html scripts validated according to regex in path
+    """
+    html_list = options.get('html', {})
+    html_returns = {}
+
+    if not isinstance(html_list, dict):
+        return html_returns
+
+    for regex, values in html_list.items():
+        regex_path_match = re.compile(regex)
+        if regex_path_match.match(path):
+            for html in values:
+                set_default_to_html = set_default_option(
+                    html,
+                    'location',
+                    ['head', 'body_start', 'body_end'],
+                    'body_start'
+                )
+
+                # Validate 'content' key in html
+                is_validate_html = check_attributes_required(
+                    set_default_to_html,
+                    ['content'],
+                    "HTML"
+                )
+
+                if is_validate_html:
+                    html_returns[set_default_to_html['location']] = set_default_to_html['content']
+
+    return html_returns

--- a/ecommerce_extensions/tenant/tests/test_extra_html.py
+++ b/ecommerce_extensions/tenant/tests/test_extra_html.py
@@ -1,0 +1,100 @@
+"""
+Tests for the extra html.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from django.test import TestCase
+from path import Path
+from testfixtures import LogCapture
+
+from ecommerce_extensions.tenant.extra_html import process_html
+from ecommerce_extensions.tenant.extra_options import ERROR_MESSAGE, check_attributes_required
+
+
+class TestsProcessExtraHtml(TestCase):
+    """ Tests for extra html"""
+
+    def test_returned_process_html(self):
+        """
+        Test process_html function returns a dictionary with all the valid html
+        in the correct order.
+        """
+        path = Path("/test")
+        tenantoptions = {
+            "html": {
+                ".*/test": [
+                    {
+                        "content": "<h1>Hola Mundo START!</h1>"
+                    },
+                    {
+                        "location": "body_end",
+                        "content": "<h1>Hola Mundo END!</h1>"
+                    },
+                ]
+            }
+        }
+        test_html = {
+            "body_start": "<h1>Hola Mundo START!</h1>",
+            "body_end": "<h1>Hola Mundo END!</h1>"
+        }
+
+        html_returns = process_html(path, tenantoptions)
+
+        self.assertEqual(test_html, html_returns)
+
+    def test_returned_(self):
+        """
+        Test process_html function returns only the html that have a valid configuration.
+        """
+        path = Path("/test")
+        tenantoptions = {
+            "html": {
+                ".*/test": [
+                    {
+                        "conten": "<h1>Hola Mundo END!</h1>"
+                    },
+                ]
+            }
+        }
+
+        html_returns = process_html(path, tenantoptions)
+
+        self.assertEqual({}, html_returns)
+
+    def test_returned_path_html(self):
+        """
+        Test process_html function returns only the html that match the current request path.
+        """
+        path = Path("/test")
+        tenantoptions = {
+            "html": {
+                ".*/dashboard": [
+                    {
+                        "location": "bodyend",
+                        "content": "<h1>Hola Mundo END!</h1>"
+                    },
+                ]
+            }
+        }
+
+        html_returns = process_html(path, tenantoptions)
+
+        self.assertEqual({}, html_returns)
+
+    def test_check_attributes_required_fails_silently(self):
+        """
+        Test check_attributes_required function logs error when a html has a missing/incorrect attribute.
+        """
+        values = {}
+        attributes = ['content']
+        log_message = "{prefix} {error_message}".format(prefix="HTML", error_message=ERROR_MESSAGE) % attributes
+
+        with LogCapture() as log:
+            check_attributes_required(
+                values,
+                attributes,
+                "HTML"
+            )
+            log.check(("ecommerce_extensions.tenant.extra_options",
+                       "ERROR",
+                       log_message))


### PR DESCRIPTION
This PR allows adding custom html for each template of ecommerce.

For example: to add a specific html to the basket template, add the path and the configurations of the html
to the tenant options.
"THEME_OPTIONS": { "html": { "/basket": [ { "location": "body_start", "content": "`<h1>Hello World!</h1>`" } ] } }

The attributes that can be specified are:

content: to indicate the code html
location : 'head', 'body_start', 'body_end'
The location attribute has 'body_start' as its default value.
the 'content' attribute must have the html.